### PR TITLE
split command creates shell script run_fit_predict.sh

### DIFF
--- a/zairachem/cli/commands/split.py
+++ b/zairachem/cli/commands/split.py
@@ -16,9 +16,11 @@ MIN_POSITIVE_CASES_FOLD = 1  # Each fold to be used for testing should have at l
 
 
 def check_dataset_minimum_size(df, fold_id):
-    """Check if a fold of a dataset:
+    """Issue warnings if dataset size requirements are not met
+    
+    Check if a fold of a dataset:
         - Has too few cases (less than MIN_CASES_FOLD)
-        - Has too few percent of total cases (less than MIN_PCT_FOLD)
+        - Has too low percent of total cases (less than MIN_PCT_FOLD %)
         - Has too few positive cases (less than MIN_POSITIVE_CASES_FOLD)
     If any of this happens, issue a warning.
     """
@@ -47,7 +49,9 @@ def create_dataset_csv(df_subset, csv_dir, csv_name):
 
 
 def create_datasets_for_fold(df, test_fold_id, all_fold_ids, output_dir):
-    """Given a dataset and a fold id, create three csv files with:
+    """Based on dataframe df, create three split datasets as csv files
+    
+    Given a dataset and a fold id, create three csv files with:
     - test.csv: For test, contains fold indicated by test_fold_id
     - train.csv: For training, contains all folds except test_fold_id
     - input_discarded.csv: Contains all cases that do not have an assigned fold
@@ -68,6 +72,87 @@ def create_datasets_for_fold(df, test_fold_id, all_fold_ids, output_dir):
     create_dataset_csv(df[df.fold.isnull()], output_dir, 'input_discarded.csv')
 
 
+def create_dir_if_not_exists(path_dir):
+    if not os.path.isdir(path_dir):
+        os.mkdir(path_dir)
+
+
+def create_all_datasets(df, folds_dir, kfold):
+    """Create all split datasets and required directories
+
+    In each fold, create split datasets by calling create_datasets_for_fold.
+    Also create required directories.
+
+    Returns: set of all fold ids
+    """
+    fold_counts = df.fold.value_counts(sort=True)  # Number of cases in each fold
+    num_folds = len(fold_counts)  # Number of folds
+    all_fold_ids = set(fold_counts.index.astype(int))  # Set of all fold ids
+
+    if not kfold:
+        # Default: simple split into train and test datasets
+        # The second largest fold, as defined by the "fold" variable, will be the test dataset.
+        # The other folds will be in the train dataset.
+        test_fold_id = fold_counts.index[1]  # Second largest fold
+        create_datasets_for_fold(df, test_fold_id, all_fold_ids, folds_dir)
+    else:
+        # Option --kfold, for k-fold cross-validation
+        # Create a directory for each fold, each with a train and test dataset
+        for current_fold_id in all_fold_ids:
+            # Create a directory for the fold, if it does not exist
+            current_fold_dir = os.path.join(folds_dir, f'fold_{current_fold_id}')
+            create_dir_if_not_exists(current_fold_dir)
+            # Within each fold, create directories model and test
+            create_dir_if_not_exists(os.path.join(current_fold_dir, 'model'))
+            create_dir_if_not_exists(os.path.join(current_fold_dir, 'test'))
+            # Create datasets with the split data
+            create_datasets_for_fold(df, current_fold_id, all_fold_ids, current_fold_dir)
+
+    return all_fold_ids
+
+
+def generate_shell_script(all_fold_ids, folds_dir, kfold):
+    """Create shell script 'run_fit_predict.sh'
+    
+    Create a shell script to automatically run Zairachem fit and predict
+    using the train and test datasets generated previously.
+    """
+    f = open('fit_predict_all.sh', 'w')
+
+    if not kfold:  # Option --kfold not active
+        path_train_dataset = os.path.join(folds_dir, 'train.csv')
+        path_test_dataset = os.path.join(folds_dir, 'test.csv')
+        f.write(f'echo --------------------------------------------------\n')
+        f.write(f'echo Running zairachem fit with train dataset\n')
+        f.write(f'echo --------------------------------------------------\n')
+        f.write(f'zairachem fit -i {path_train_dataset} -m model\n')
+        f.write(f'echo --------------------------------------------------\n')
+        f.write(f'echo Running zairachem predict with test dataset\n')
+        f.write(f'echo --------------------------------------------------\n')
+        f.write(f'zairachem predict -i {path_test_dataset} -m model -o test --clean\n')
+        logger.info('The shell script assumes the model directory is "model",'
+                ' otherwise please edit fit_predict_all.sh manually.')
+    else:  # Option --kfold active
+        for current_fold_id in all_fold_ids:
+            current_fold_dir = os.path.join(folds_dir, f'fold_{current_fold_id}')
+            path_train_dataset = os.path.join(current_fold_dir, 'train.csv')
+            path_test_dataset = os.path.join(current_fold_dir, 'test.csv')
+            path_model_dir = os.path.join(current_fold_dir, 'model')
+            path_test_dir = os.path.join(current_fold_dir, 'test')
+            f.write(f'echo --------------------------------------------------\n')
+            f.write(f'echo Fold {current_fold_id} - Running zairachem fit with train dataset\n')
+            f.write(f'echo --------------------------------------------------\n')
+            f.write(f'zairachem fit -i {path_train_dataset} -m {path_model_dir}\n')
+            f.write(f'echo --------------------------------------------------\n')
+            f.write(f'echo Fold {current_fold_id} - Running zairachem predict with test dataset\n')
+            f.write(f'echo --------------------------------------------------\n')
+            f.write(f'zairachem predict -i {path_test_dataset} -m {path_model_dir}'
+                    f' -o {path_test_dir} --clean\n')
+
+    logger.info(f'Shell script fit_predict_all.sh created in current directory ({os.getcwd()}).')
+    f.close()
+
+
 def split_cmd():
     @zairachem_cli.command(help="Split input data set for cross-validation")
     @click.option("--input_file", "-i", type=click.STRING, required=True)
@@ -84,22 +169,9 @@ def split_cmd():
         # folds_dir: if not specified, use the same dir as input_file
         if folds_dir is None:
             folds_dir = os.path.dirname(input_file)
-        logger.debug(f"Split datasets will be stored at {folds_dir}")
+        logger.info(f"Split datasets will be stored at {folds_dir}")
 
-        # Depending on split_criterion, select the variable to use for fold assignments
-        if split_criterion == 'random':
-            fold_var = 'fld_rnd'
-        elif split_criterion == 'scaffold':
-            fold_var = 'fld_scf'
-        elif split_criterion == 'similarity':
-            fold_var = 'fld_lsh'
-        elif split_criterion == 'default':
-            fold_var = 'fld_aux'
-        else:
-            logger.error(f'Invalid value "{split_criterion}" for parameter --split_criterion.')
-            sys.exit(1)
-            
-        # Create directory to store the output of TrainSetup
+        # Create temporary directory to store the output of TrainSetup
         tmp_output_dir = tempfile.mkdtemp()
 
         # The TrainSetup method will generate the fold assignments
@@ -116,8 +188,6 @@ def split_cmd():
             augment=False,
         )
         s.setup()
-        # FOR TESTING USE /home/marcos/split_dev/model instead of calling s.setup() (which takes long)
-        # tmp_output_dir = '/home/marcos/split_dev/model'
 
         # Read files with input data and fold assignments
         df_input = pd.read_csv(input_file)
@@ -138,28 +208,24 @@ def split_cmd():
                 left_on='uniq_idx',
                 right_index=True)
 
+        # Depending on split_criterion, select the variable to use for fold assignments
+        if split_criterion == 'random':
+            fold_var = 'fld_rnd'
+        elif split_criterion == 'scaffold':
+            fold_var = 'fld_scf'
+        elif split_criterion == 'similarity':
+            fold_var = 'fld_lsh'
+        elif split_criterion == 'default':
+            fold_var = 'fld_aux'
+        else:
+            logger.error(f'Invalid value "{split_criterion}" for parameter --split_criterion.')
+            sys.exit(1)
+
         # Create variable "fold" according to parameter --split_criterion
         df['fold'] = df[fold_var]
 
-        fold_counts = df.fold.value_counts(sort=True)  # Number of cases in each fold
-        num_folds = len(fold_counts)  # Number of folds
-        all_fold_ids = set(fold_counts.index.astype(int))  # Set of all fold ids
+        all_fold_ids = create_all_datasets(df, folds_dir, kfold)
 
-        if not kfold:
-            # Default: simple split into train and test datasets
-            # The second largest fold, as defined by the "fold" variable, will define the test dataset.
-            # The other folds will be in the train split.
-            test_fold_id = fold_counts.index[1]  # Second largest fold
-            create_datasets_for_fold(df, test_fold_id, all_fold_ids, folds_dir)
-        else:
-            # Option --kfold, for k-fold cross-validation
-            # Create a directory for each fold, each with a train and test dataset
-            for current_fold_id in all_fold_ids:
-                # Create a directory for the fold, if it does not exist
-                current_fold_dir = os.path.join(folds_dir, f'fold_{current_fold_id}')
-                if not os.path.isdir(current_fold_dir):
-                    os.mkdir(current_fold_dir)
-
-                create_datasets_for_fold(df, current_fold_id, all_fold_ids, current_fold_dir)
+        generate_shell_script(all_fold_ids, folds_dir, kfold)
 
         echo("Done", fg="green")


### PR DESCRIPTION
The split command generates a shell script, run_fit_predict.sh, that can be run afterwards to fit and predict using the generated splits.
Note: The development of the main split functionality was performed outside of the branch "split-cmd", using direct commits. Sorry for the inconvenience. The branch "split-cmd" contains only some posterior refactoring and the addition of the feature to create "run_fit_predict.sh".