### PR TITLE
Use Python=3.10

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,11 +1,12 @@
 WORKDIR=$PWD
 
-conda init bash
+#conda init bash
+eval "$(conda shell.bash hook)"
 
 # create zairachem conda environment
 ZAIRACHEM_ENVIRONMENT='zairachem'
-conda create -n $ZAIRACHEM_ENVIRONMENT python=3.7 -y
-source $CONDA_PREFIX/etc/profile.d/conda.sh
+conda create -n $ZAIRACHEM_ENVIRONMENT python=3.10 -y
+#source $CONDA_PREFIX/etc/profile.d/conda.sh
 conda activate $ZAIRACHEM_ENVIRONMENT
 
 # pip
@@ -15,11 +16,11 @@ python3 -m pip install tables openpyxl
 
 # other pip-installable dependencies
 python3 -m pip install tensorflow==2.10.0
-python3 -m pip install autokeras==1.0.20 #==1.0.16
+python3 -m pip install autokeras==1.0.20 #==1.0.16  
 
 # install autogluon cpu
 python3 -m pip install -U "mxnet<2.0.0"
-python3 -m pip install autogluon.tabular[all]==0.5.2
+python3 -m pip install autogluon.tabular[all]==0.7.0
 
 # install autogluon gpu
 # Here we assume CUDA 10.1 is installed.  You should change the number

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3381c7faebc313688e09d8a1603b0c8f41d862cad3c5f1f1aca3e2dd2e8cf88e
-size 130
+oid sha256:2390c648cd96ced37726ca202a1932eefa6801abfda19626aff94ec0421661ff
+size 241

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2390c648cd96ced37726ca202a1932eefa6801abfda19626aff94ec0421661ff
-size 241
+oid sha256:3e1bfff5a151df0c8068e127e668956751fd38c96bcd077b0cde66d5739d7b6c
+size 272


### PR DESCRIPTION
Hello @GemmaTuron  and @miquelduranfrigola,
To slove the dependencies, https://github.com/ersilia-os/zaira-chem/issues/37, This PR introduces usage of Python=3.10 within the zairachem conda environment, and to specify working versions for the packages.